### PR TITLE
Change build type

### DIFF
--- a/.github/workflows/build_cmake.yml
+++ b/.github/workflows/build_cmake.yml
@@ -12,7 +12,7 @@ env:
   ELFUTILS_VERSION: 0.175
   CMAKE_VERSION: 3.21.1
   NINJA_VERSION: 1.10.2
-  BUILD_TYPE: Release
+  BUILD_TYPE: Debug
   CCACHE_VERSION: 4.6
   QT_MIRRORS: download.qt.io;mirrors.ocf.berkeley.edu/qt;ftp.fau.de/qtproject;mirror.bit.edu.cn/qtproject
 


### PR DESCRIPTION
Set build type to debug to get a debug version of qtcreator

Thank you for contributing to Qt Creator! Unfortunately the GitHub Qt Creator
presence is only a git mirror.

Please submit your patch via gerrit:
https://wiki.qt.io/Qt_Creator#Setting_up_Gerrit_to_contribute_back_to_Qt_Creator

We are sorry for the inconvenience.
